### PR TITLE
Rename cookie page to avoid confusion with API usage statistics

### DIFF
--- a/FAQ.html
+++ b/FAQ.html
@@ -187,7 +187,7 @@
             <li><h2>particulier.api.gouv.fr</h2></li>
             <li><a href="https://api.gouv.fr/apropos#quest-ce-quune-api">Qu'est ce qu'une API ?</a></li>
             <li><a href="https://status.particulier.api.gouv.fr">Status des API</a></li>
-            <li><a href="statistiques.html">Statistiques d'usage</a></li>
+            <li><a href="suivi.html">Suivi d'audience et vie privée</a></li>
             <li><a href="https://api.gouv.fr/apropos#mentions-légales">Mentions légales</a></li>
             <li><a href="mailto:contact@particulier.api.gouv.fr?subject=Contact%20via%20particulier.api.gouv.fr">Contactez-nous</a></li>
         </ul>

--- a/collectivites-locales.html
+++ b/collectivites-locales.html
@@ -243,7 +243,7 @@
             <li><h2>particulier.api.gouv.fr</h2></li>
             <li><a href="https://api.gouv.fr/apropos#quest-ce-quune-api">Qu'est ce qu'une API ?</a></li>
             <li><a href="https://status.particulier.api.gouv.fr">Status des API</a></li>
-            <li><a href="statistiques.html">Statistiques d'usage</a></li>
+            <li><a href="suivi.html">Suivi d'audience et vie privée</a></li>
             <li><a href="https://api.gouv.fr/apropos#mentions-légales">Mentions légales</a></li>
             <li><a href="mailto:contact@particulier.api.gouv.fr?subject=Contact%20via%20particulier.api.gouv.fr">Contactez-nous</a></li>
         </ul>

--- a/index.html
+++ b/index.html
@@ -351,7 +351,7 @@
             <li><h2>particulier.api.gouv.fr</h2></li>
             <li><a href="https://api.gouv.fr/apropos#quest-ce-quune-api">Qu'est ce qu'une API ?</a></li>
             <li><a href="https://status.particulier.api.gouv.fr">Status des API</a></li>
-            <li><a href="statistiques.html">Statistiques d'usage</a></li>
+            <li><a href="suivi.html">Suivi d'audience et vie privée</a></li>
             <li><a href="https://api.gouv.fr/apropos#mentions-légales">Mentions légales</a></li>
             <li><a href="mailto:contact@particulier.api.gouv.fr?subject=Contact%20via%20particulier.api.gouv.fr">Contactez-nous</a></li>
         </ul>

--- a/suivi.html
+++ b/suivi.html
@@ -6,7 +6,7 @@
     <meta http-equiv="x-ua-compatible" content="ie=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <title>Statistiques d'usage - API Particulier</title>
+    <title>Suivi d'audience et vie privée - API Particulier</title>
 
     <link rel="stylesheet" href="https://unpkg.com/template.data.gouv.fr@1.1.6/dist/style/main.css">
     <link rel="stylesheet" href="css/main.css">
@@ -124,7 +124,7 @@
 
 <section class="section section-white">
     <div class="container">
-        <h1 class="section__title">Statistiques d'usage sur le site</h1>
+        <h1 class="section__title">Suivi d'audience et vie privée</h1>
         <p>
             Lorsque vous visitez ce site web, nous laissons un petit fichier texte (un "cookie") sur votre ordinateur. Cela nous permet de mesurer combien de visites nous avons et quelles sont les pages les plus regardées.
         </p>
@@ -166,7 +166,7 @@
             <li><h2>particulier.api.gouv.fr</h2></li>
             <li><a href="https://api.gouv.fr/apropos#quest-ce-quune-api">Qu'est ce qu'une API ?</a></li>
             <li><a href="https://status.particulier.api.gouv.fr">Status des API</a></li>
-            <li><a href="statistiques.html">Statistiques d'usage</a></li>
+            <li><a href="suivi.html">Statistiques d'usage</a></li>
             <li><a href="https://api.gouv.fr/apropos#mentions-légales">Mentions légales</a></li>
             <li><a href="mailto:contact@particulier.api.gouv.fr?subject=Contact%20via%20particulier.api.gouv.fr">Contactez-nous</a></li>
         </ul>


### PR DESCRIPTION
This PR renames the analytics page from 'Statistiques' to 'Suivi d'audience et vie privée'
This follows the lead from beta.gouv.fr and prevents confusion between a page that gives the statistics of the API and a page that allows a user to turn off cookies.
(⚠️ Merge this before merging #19)
Before:

<img width="1509" alt="Capture d’écran 2019-03-26 à 18 09 41" src="https://user-images.githubusercontent.com/13916213/55018059-5946c180-4ff2-11e9-8cd3-b70f9dd825f6.png">

After:
![image](https://user-images.githubusercontent.com/13916213/55018012-459b5b00-4ff2-11e9-98b5-ec7cbfbf0882.png)

