### PR TITLE
Add documentation link in header

### DIFF
--- a/FAQ.html
+++ b/FAQ.html
@@ -112,6 +112,7 @@
         <nav>
             <ul class="nav__links">
                 <li class="nav__item"><a href="collectivites-locales.html">Collectivités locales</a></li>
+                <li class="nav__item"><a href="https://api.gouv.fr/api/api-particulier.html#doc_tech">Documentation technique</a></li>
                 <li class="nav__item"><a href="FAQ.html">FAQ</a></li>
                 <li class="nav__item"><a href="mailto:contact@particulier.api.gouv.fr?subject=Contact%20via%20particulier.api.gouv.fr">Nous contacter</a></li>
             </ul>
@@ -185,14 +186,15 @@
         </div>
         <ul class="footer__links">
             <li><h2>particulier.api.gouv.fr</h2></li>
-            <li><a href="https://api.gouv.fr/apropos#quest-ce-quune-api">Qu'est ce qu'une API ?</a></li>
             <li><a href="https://status.particulier.api.gouv.fr">Status des API</a></li>
             <li><a href="suivi.html">Suivi d'audience et vie privée</a></li>
+            <li><a href="https://api.gouv.fr/api/api-particulier.html#doc_tech">Documentation technique</a></li>
             <li><a href="https://api.gouv.fr/apropos#mentions-légales">Mentions légales</a></li>
             <li><a href="mailto:contact@particulier.api.gouv.fr?subject=Contact%20via%20particulier.api.gouv.fr">Contactez-nous</a></li>
         </ul>
         <ul class='footer__links'>
             <li><h2>api.gouv.fr</h2></li>
+            <li><a href="https://api.gouv.fr/apropos#quest-ce-quune-api">Qu'est ce qu'une API ?</a></li>
             <li><a href="http://beta.gouv.fr/" rel="noopener" target="_blank">Une réalisation de beta.gouv.fr</a></li>
             <li><a href="http://modernisation.gouv.fr/" rel="noopener" target="_blank">Une mission de la DINSIC</a></li>
             <li><a href="http://etatplateforme.modernisation.gouv.fr/" target="_blank">Un site de l'État plateforme</a></li>

--- a/FAQ.html
+++ b/FAQ.html
@@ -187,7 +187,7 @@
             <li><h2>particulier.api.gouv.fr</h2></li>
             <li><a href="https://api.gouv.fr/apropos#quest-ce-quune-api">Qu'est ce qu'une API ?</a></li>
             <li><a href="https://status.particulier.api.gouv.fr">Status des API</a></li>
-            <li><a href="statistiques.html">Statistiques d'usage</a></li>
+            <li><a href="suivi.html">Suivi d'audience et vie privée</a></li>
             <li><a href="https://api.gouv.fr/apropos#mentions-légales">Mentions légales</a></li>
             <li><a href="mailto:contact@particulier.api.gouv.fr?subject=Contact%20via%20particulier.api.gouv.fr">Contactez-nous</a></li>
         </ul>

--- a/collectivites-locales.html
+++ b/collectivites-locales.html
@@ -112,6 +112,7 @@
         <nav>
             <ul class="nav__links">
                 <li class="nav__item"><a href="collectivites-locales.html">Collectivités locales</a></li>
+                <li class="nav__item"><a href="https://api.gouv.fr/api/api-particulier.html#doc_tech">Documentation technique</a></li>
                 <li class="nav__item"><a href="FAQ.html">FAQ</a></li>
                 <li class="nav__item"><a href="mailto:contact@particulier.api.gouv.fr?subject=Contact%20via%20particulier.api.gouv.fr">Nous contacter</a></li>
             </ul>
@@ -241,14 +242,15 @@
         </div>
         <ul class="footer__links">
             <li><h2>particulier.api.gouv.fr</h2></li>
-            <li><a href="https://api.gouv.fr/apropos#quest-ce-quune-api">Qu'est ce qu'une API ?</a></li>
             <li><a href="https://status.particulier.api.gouv.fr">Status des API</a></li>
             <li><a href="suivi.html">Suivi d'audience et vie privée</a></li>
+            <li><a href="https://api.gouv.fr/api/api-particulier.html#doc_tech">Documentation technique</a></li>
             <li><a href="https://api.gouv.fr/apropos#mentions-légales">Mentions légales</a></li>
             <li><a href="mailto:contact@particulier.api.gouv.fr?subject=Contact%20via%20particulier.api.gouv.fr">Contactez-nous</a></li>
         </ul>
         <ul class='footer__links'>
             <li><h2>api.gouv.fr</h2></li>
+            <li><a href="https://api.gouv.fr/apropos#quest-ce-quune-api">Qu'est ce qu'une API ?</a></li>
             <li><a href="http://beta.gouv.fr/" rel="noopener" target="_blank">Une réalisation de beta.gouv.fr</a></li>
             <li><a href="http://modernisation.gouv.fr/" rel="noopener" target="_blank">Une mission de la DINSIC</a></li>
             <li><a href="http://etatplateforme.modernisation.gouv.fr/" target="_blank">Un site de l'État plateforme</a></li>

--- a/collectivites-locales.html
+++ b/collectivites-locales.html
@@ -243,7 +243,7 @@
             <li><h2>particulier.api.gouv.fr</h2></li>
             <li><a href="https://api.gouv.fr/apropos#quest-ce-quune-api">Qu'est ce qu'une API ?</a></li>
             <li><a href="https://status.particulier.api.gouv.fr">Status des API</a></li>
-            <li><a href="statistiques.html">Statistiques d'usage</a></li>
+            <li><a href="suivi.html">Suivi d'audience et vie privée</a></li>
             <li><a href="https://api.gouv.fr/apropos#mentions-légales">Mentions légales</a></li>
             <li><a href="mailto:contact@particulier.api.gouv.fr?subject=Contact%20via%20particulier.api.gouv.fr">Contactez-nous</a></li>
         </ul>

--- a/index.html
+++ b/index.html
@@ -351,7 +351,7 @@
             <li><h2>particulier.api.gouv.fr</h2></li>
             <li><a href="https://api.gouv.fr/apropos#quest-ce-quune-api">Qu'est ce qu'une API ?</a></li>
             <li><a href="https://status.particulier.api.gouv.fr">Status des API</a></li>
-            <li><a href="statistiques.html">Statistiques d'usage</a></li>
+            <li><a href="suivi.html">Suivi d'audience et vie privée</a></li>
             <li><a href="https://api.gouv.fr/apropos#mentions-légales">Mentions légales</a></li>
             <li><a href="mailto:contact@particulier.api.gouv.fr?subject=Contact%20via%20particulier.api.gouv.fr">Contactez-nous</a></li>
         </ul>

--- a/index.html
+++ b/index.html
@@ -114,6 +114,7 @@
         <nav>
             <ul class="nav__links">
                 <li class="nav__item"><a href="collectivites-locales.html">Collectivités locales</a></li>
+                <li class="nav__item"><a href="https://api.gouv.fr/api/api-particulier.html#doc_tech">Documentation technique</a></li>
                 <li class="nav__item"><a href="FAQ.html">FAQ</a></li>
                 <li class="nav__item"><a href="mailto:contact@particulier.api.gouv.fr?subject=Contact%20via%20particulier.api.gouv.fr">Nous contacter</a></li>
             </ul>
@@ -349,14 +350,15 @@
         </div>
         <ul class="footer__links">
             <li><h2>particulier.api.gouv.fr</h2></li>
-            <li><a href="https://api.gouv.fr/apropos#quest-ce-quune-api">Qu'est ce qu'une API ?</a></li>
             <li><a href="https://status.particulier.api.gouv.fr">Status des API</a></li>
             <li><a href="suivi.html">Suivi d'audience et vie privée</a></li>
+            <li><a href="https://api.gouv.fr/api/api-particulier.html#doc_tech">Documentation technique</a></li>
             <li><a href="https://api.gouv.fr/apropos#mentions-légales">Mentions légales</a></li>
             <li><a href="mailto:contact@particulier.api.gouv.fr?subject=Contact%20via%20particulier.api.gouv.fr">Contactez-nous</a></li>
         </ul>
         <ul class='footer__links'>
             <li><h2>api.gouv.fr</h2></li>
+            <li><a href="https://api.gouv.fr/apropos#quest-ce-quune-api">Qu'est ce qu'une API ?</a></li>
             <li><a href="http://beta.gouv.fr/" rel="noopener" target="_blank">Une réalisation de beta.gouv.fr</a></li>
             <li><a href="http://modernisation.gouv.fr/" rel="noopener" target="_blank">Une mission de la DINSIC</a></li>
             <li><a href="http://etatplateforme.modernisation.gouv.fr/" target="_blank">Un site de l'État plateforme</a></li>

--- a/suivi.html
+++ b/suivi.html
@@ -6,7 +6,7 @@
     <meta http-equiv="x-ua-compatible" content="ie=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <title>Statistiques d'usage - API Particulier</title>
+    <title>Suivi d'audience et vie privée - API Particulier</title>
 
     <link rel="stylesheet" href="https://unpkg.com/template.data.gouv.fr@1.1.6/dist/style/main.css">
     <link rel="stylesheet" href="css/main.css">
@@ -124,7 +124,7 @@
 
 <section class="section section-white">
     <div class="container">
-        <h1 class="section__title">Statistiques d'usage sur le site</h1>
+        <h1 class="section__title">Suivi d'audience et vie privée</h1>
         <p>
             Lorsque vous visitez ce site web, nous laissons un petit fichier texte (un "cookie") sur votre ordinateur. Cela nous permet de mesurer combien de visites nous avons et quelles sont les pages les plus regardées.
         </p>
@@ -166,7 +166,7 @@
             <li><h2>particulier.api.gouv.fr</h2></li>
             <li><a href="https://api.gouv.fr/apropos#quest-ce-quune-api">Qu'est ce qu'une API ?</a></li>
             <li><a href="https://status.particulier.api.gouv.fr">Status des API</a></li>
-            <li><a href="statistiques.html">Statistiques d'usage</a></li>
+            <li><a href="suivi.html">Statistiques d'usage</a></li>
             <li><a href="https://api.gouv.fr/apropos#mentions-légales">Mentions légales</a></li>
             <li><a href="mailto:contact@particulier.api.gouv.fr?subject=Contact%20via%20particulier.api.gouv.fr">Contactez-nous</a></li>
         </ul>

--- a/suivi.html
+++ b/suivi.html
@@ -115,6 +115,7 @@
         <nav>
             <ul class="nav__links">
                 <li class="nav__item"><a href="collectivites-locales.html">Collectivités locales</a></li>
+                <li class="nav__item"><a href="https://api.gouv.fr/api/api-particulier.html#doc_tech">Documentation technique</a></li>
                 <li class="nav__item"><a href="FAQ.html">FAQ</a></li>
                 <li class="nav__item"><a href="mailto:contact@particulier.api.gouv.fr?subject=Contact%20via%20particulier.api.gouv.fr">Nous contacter</a></li>
             </ul>
@@ -164,14 +165,15 @@
         </div>
         <ul class="footer__links">
             <li><h2>particulier.api.gouv.fr</h2></li>
-            <li><a href="https://api.gouv.fr/apropos#quest-ce-quune-api">Qu'est ce qu'une API ?</a></li>
             <li><a href="https://status.particulier.api.gouv.fr">Status des API</a></li>
             <li><a href="suivi.html">Statistiques d'usage</a></li>
+            <li><a href="https://api.gouv.fr/api/api-particulier.html#doc_tech">Documentation technique</a></li>
             <li><a href="https://api.gouv.fr/apropos#mentions-légales">Mentions légales</a></li>
             <li><a href="mailto:contact@particulier.api.gouv.fr?subject=Contact%20via%20particulier.api.gouv.fr">Contactez-nous</a></li>
         </ul>
         <ul class='footer__links'>
             <li><h2>api.gouv.fr</h2></li>
+            <li><a href="https://api.gouv.fr/apropos#quest-ce-quune-api">Qu'est ce qu'une API ?</a></li>
             <li><a href="http://beta.gouv.fr/" rel="noopener" target="_blank">Une réalisation de beta.gouv.fr</a></li>
             <li><a href="http://modernisation.gouv.fr/" rel="noopener" target="_blank">Une mission de la DINSIC</a></li>
             <li><a href="http://etatplateforme.modernisation.gouv.fr/" target="_blank">Un site de l'État plateforme</a></li>


### PR DESCRIPTION
This PR adds a link to the technical documentation in the header to help implementors find quicly the ressources they need.

This PR also adds the link to the footer and moves "Qu'est ce qu'une API" to the api.gouv.fr column in the footer.
(⚠️ merge this after you merged #18)

Before:
<img width="1552" alt="Capture d’écran 2019-03-26 à 18 14 06" src="https://user-images.githubusercontent.com/13916213/55018361-fe619a00-4ff2-11e9-96dd-bedc7af80620.png">

After:
<img width="1678" alt="Capture d’écran 2019-03-26 à 18 13 45" src="https://user-images.githubusercontent.com/13916213/55018330-eab63380-4ff2-11e9-9fc0-c1eff35b69c6.png">
